### PR TITLE
Add diff limit to sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -135,18 +135,26 @@ jobs:
             echo "USE_LLM=false" >> $GITHUB_ENV
           fi
           
-          if [[ "$USE_LLM" == "true" ]]; then
+          # Calculate diff size to avoid generating prompts that exceed model limits
+          MAX_DIFF_LINES=20000
+          DIFF_LINES=$(git diff fork_upstream | wc -l)
+          echo "Diff contains $DIFF_LINES lines"
+
+          if [[ "$USE_LLM" == "true" && "$DIFF_LINES" -le "$MAX_DIFF_LINES" ]]; then
             # Generate PR description using aipr
             echo "Generating PR description using $LLM_MODEL..."
             # Save current branch and target for reference
             CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
             TARGET_BRANCH="fork_upstream"
-            
-            # Use the aipr tool with the --vulns flag
-            PR_DESCRIPTION=$(aipr -t $TARGET_BRANCH --vulns -p meta -m $LLM_MODEL)
-            
+
+            # Use the aipr tool with the --vulns flag and diff limit parameter
+            PR_DESCRIPTION=$(aipr -t $TARGET_BRANCH --vulns -p meta -m $LLM_MODEL --max-diff-lines $MAX_DIFF_LINES)
+
             echo "Generated enhanced PR description using $LLM_MODEL"
           else
+            if [[ "$DIFF_LINES" -gt "$MAX_DIFF_LINES" ]]; then
+              echo "Diff is larger than $MAX_DIFF_LINES lines; skipping aipr description"
+            fi
             # Use default PR description
             PR_DESCRIPTION="Automated PR to sync with upstream repository changes.
 

--- a/doc/sync-workflow.md
+++ b/doc/sync-workflow.md
@@ -66,6 +66,10 @@ sequenceDiagram
 
 If the merge is clean, a pull request is automatically generated against the fork_upstream branch. The PR contains a summary of the upstream changes, allowing maintainers to review, test, and merge the updates before they reach the main development branch.
 
+### Diff Size Limits for PR Descriptions
+
+To avoid creating prompts that exceed the language model's maximum context size, the workflow checks the diff size before generating the pull request description. If more than 20,000 lines differ from the `fork_upstream` branch, the enhanced description step is skipped and a default message is used instead. Otherwise, the `aipr` tool is invoked with a matching diff limit to keep the generated prompt within bounds.
+
 ## Conclusion
 
 Maintaining an up-to-date fork is essential for ensuring compatibility with upstream changes. This workflow automates much of the synchronization process, reducing the burden on developers while ensuring stability and transparency. By regularly integrating upstream updates and managing conflicts proactively, this workflow helps maintain a clean and efficient development environment.


### PR DESCRIPTION
## Summary
- skip aipr if diff is larger than 20k lines and fall back to default PR description
- document diff limit behavior in sync workflow docs

## Testing
- `true`